### PR TITLE
Upgrade schema generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ venv/
 *.egg-info
 Makefile
 test.py
+.DS_Store
+.idea
+.src/.DS_Store

--- a/src/schema_generator/schema_attributes.py
+++ b/src/schema_generator/schema_attributes.py
@@ -2,6 +2,8 @@ from typing import List, Type, TypeVar
 import types
 from .utils import get_inner
 from .t import T
+import re
+
 
 class SchemaAttributes:
     """
@@ -31,7 +33,7 @@ class SchemaAttributes:
         setattr(cls, "ALL", attributes)
         setattr(cls, "ENTITIES", entities)
 
-    
+
     class Config:
         """
         Allow to define a mapping for dynamic schemas, for example:\n
@@ -51,6 +53,17 @@ class SchemaAttributes:
         In this example, the schema for the team inside the schema UserPatch will be TeamCreate (instead of TeamPatch)\n
         """
 
-        mapping = {
-            "ReadAll": "Read"
+        @classmethod
+        def apply_default_mapping(cls, method_name):
+            for pattern, replacement in cls.default_mapping.items():
+                regex_pattern = re.compile(pattern.replace("*", ".*"))
+                if regex_pattern.match(method_name):
+                    return replacement
+            return method_name
+
+        default_mapping = {
+            "Read*": "Read",
+            "Patch*": "Patch",
+            "Create*": "Create"
         }
+        mapping = {}

--- a/src/schema_generator/schema_attributes.py
+++ b/src/schema_generator/schema_attributes.py
@@ -61,9 +61,5 @@ class SchemaAttributes:
                     return replacement
             return method_name
 
-        default_mapping = {
-            "Read*": "Read",
-            "Patch*": "Patch",
-            "Create*": "Create"
-        }
+        default_mapping = {}
         mapping = {}


### PR DESCRIPTION
PR pour déterminer des patterns par défaut sur le schema générator. Utilisation depuis TikiBack:

from schema_generator import SchemaAttributes

SchemaAttributes.Config.mapping = {**SchemaAttributes.Config.mapping}
SchemaAttributes.Config.default_mapping = {
    **SchemaAttributes.Config.default_mapping,
    "Read*": "Read",
    "Patch*": "Patch",
    "Create*": "Create",
}

Tous les schemas qui commencent par Read pointeront par défaut sur Read de l'entité enfant (meme délire pour patch et create), et en plus de cela il sera possible de déterminer ici des nouveaux patterns pour le mappiing :)